### PR TITLE
pymc-extras 0.3.1 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/better-optimize-feedstock/pr1/587f2dd
-  - https://staging.continuum.io/prefect/fs/pytensor-feedstock/pr10/10ab31c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/pymc-feedstock/pr5/e58767c
   - https://staging.continuum.io/prefect/fs/better-optimize-feedstock/pr1/587f2dd
   - https://staging.continuum.io/prefect/fs/pytensor-feedstock/pr10/10ab31c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/pymc-feedstock/pr5/c5a16f9
+  - https://staging.continuum.io/prefect/fs/pymc-feedstock/pr5/e58767c
   - https://staging.continuum.io/prefect/fs/better-optimize-feedstock/pr1/587f2dd
+  - https://staging.continuum.io/prefect/fs/pytensor-feedstock/pr10/10ab31c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/pymc-feedstock/pr5/c5a16f9
+  - https://staging.continuum.io/prefect/fs/better-optimize-feedstock/pr1/587f2dd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,6 @@ test:
     - pip
     - pytest >=6.0
     - pytest-mock
-    - preliz >=0.5.0
     - statsmodels
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<311]
+  # pymc 5.23 is available only for py 311 and 312
+  skip: True  # [py<311 or py>312]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,47 +1,69 @@
 {% set name = "pymc-extras" %}
 {% set version = "0.3.1" %}
-{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pymc_extras-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: d1c93f81b9439d202a751946363951b8e643b3ec27644fb46ef43807d7c26715
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<311]
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - hatch-vcs
     - pip
   run:
-    - python >={{ python_min }}
-    - pymc >=5.21.1
+    - python
+    # ImportError: cannot import name 'CustomProgress' from 'pymc.util'
+    # https://github.com/pymc-devs/pymc/blob/v5.23.0/pymc/util.py#L578
+    # CustomProgress avaliable in version <5.24.0
+    - pymc >=5.21.1,<5.24.0
     - scikit-learn
     - better-optimize >=0.1.4
     - pydantic >=2.0.0
+    # ModuleNotFoundError: No module named 'pytensor'
+    # https://github.com/pymc-devs/pymc-extras/blob/main/pymc_extras/gp/latent_approx.py#L18
+    - pytensor
+  run_constrained:
+    # complete, dask_histogram
+    - dask <2025.1.1
 
 test:
+  source_files:
+    - tests
   imports:
     - pymc_extras
   commands:
     - pip check
+    # Tests passed locally, but tests need more than 30 minutes each Python iteration. Skipped.
+    #- pytest -v tests
   requires:
-    - python {{ python_min }}
     - pip
+    - pytest >=6.0
+    - pytest-mock
+    - preliz >=0.5.0
+    - statsmodels
 
 about:
   home: https://github.com/pymc-devs/pymc-extras
   summary: A home for new additions to PyMC, which may include unusual probability distribitions, advanced model fitting algorithms, or any code that may be inappropriate to include in the pymc repository, but may want to be made available to users.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  description: |
+    As PyMC continues to mature and expand its functionality to accommodate
+    more domains of application, we increasingly see cutting-edge methodologies,
+    highly specialized statistical distributions,and complex models appear.
+  doc_url: https://www.pymc.io/projects/extras
+  dev_url: https://github.com/pymc-devs/pymc-extras
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,9 @@ requirements:
     - pydantic >=2.0.0
     # ModuleNotFoundError: No module named 'pytensor'
     # https://github.com/pymc-devs/pymc-extras/blob/main/pymc_extras/gp/latent_approx.py#L18
-    - pytensor
+    # ModuleNotFoundError: No module named 'pytensor.tensor.optimize'
+    # pytensor.tensor.optimize added from version 2.31.6
+    - pytensor >=2.31.6
   run_constrained:
     # complete, dask_histogram
     - dask <2025.1.1


### PR DESCRIPTION
pymc-extras 0.3.1 

**Destination channel:** Defaults

### Links

- [PKG-8513]
- dev_url:        https://github.com/pymc-devs/pymc-extras/tree/v0.3.1
- conda_forge:    https://github.com/conda-forge/pymc-extras-feedstock
- pypi:           https://pypi.org/project/pymc-extras/0.3.1
- pypi inspector: https://inspector.pypi.io/project/pymc-extras/0.3.1

### Explanation of changes:

- new version number


[PKG-8513]: https://anaconda.atlassian.net/browse/PKG-8513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ